### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,5 @@ Una vez terminado, cada equipo monta su módulo en `src/index.ts`
 
 ## DevCode
 - Johan
+- Cesar Luis
+  


### PR DESCRIPTION
Restringir operaciones por saldo negativo
Descripción:

Como sistema, quiero restringir la capacidad de un Fixer para aceptar nuevos trabajos o publicar nuevas ofertas si el saldo de su billetera es negativo, para forzar el cumplimiento de los pagos de comisiones pendientes.

Criterios de Aceptación:

Verificar que el sistema detecte automáticamente cuando el saldo de la billetera del fixer sea negativo.
Verificar que el sistema impida al fixer aceptar nuevos trabajos mientras tenga saldo negativo.
Verificar que el sistema bloquee la opción de publicar nuevas ofertas con saldo negativo.
Verificar que se muestre un mensaje claro informando que el saldo negativo impide realizar acciones.
Verificar que el mensaje de advertencia indique el motivo y las acciones necesarias para resolverlo.
Verificar que el botón “Aceptar trabajo” esté deshabilitado cuando el saldo sea negativo.
Verificar que el botón “Publicar oferta” no esté disponible o muestre un aviso de restricción.
Verificar que el sistema registre en la base de datos la causa de la restricción (saldo negativo).
Verificar que el fixer no pueda evadir la restricción actualizando manualmente su perfil o sesión.
Verificar que, al regularizar el saldo, el sistema elimine automáticamente las restricciones.
Verificar que el saldo actualizado se refleje en tiempo real en la interfaz del fixer.
Verificar que se registre un log del cambio de estado de la cuenta (de restringida a activa).
Verificar que el sistema no permita crear ofertas en borrador mientras el saldo sea negativo.
Verificar que el sistema notifique al fixer por correo o alerta interna sobre el estado negativo.
Verificar que el sistema no permita aceptar trabajos enviados por otros usuarios durante la restricción.
Verificar que la restricción no afecte otras funciones ajenas a la publicación o aceptación de trabajos.
Verificar que el sistema mantenga la restricción aunque el fixer cierre y vuelva a iniciar sesión.
Verificar que el sistema muestre correctamente el saldo negativo en la billetera del fixer.
Verificar que la validación de saldo negativo se aplique tanto en web como en aplicación móvil.
Verificar que el sistema permita nuevamente aceptar y publicar ofertas una vez que el saldo sea positivo.
Verificar que el sistema actualice el estado del fixer a “restringido” al detectar saldo negativo.
Verificar que la restricción por saldo negativo se mantenga tras recargar o actualizar la página.
Verificar que el sistema registre la fecha y hora en que se aplicó la restricción al fixer.
Verificar que el sistema no permita enviar solicitudes de trabajo mientras la cuenta esté restringida.
Verificar que el sistema muestre el motivo de la restricción en la sección de billetera del fixer.