### PR TITLE
fix(backend): Bug 1.1.1 - Soporte completo para campo bio

### DIFF
--- a/src/modules/fixer/services/fixers.service.ts
+++ b/src/modules/fixer/services/fixers.service.ts
@@ -542,6 +542,22 @@ class FixersService {
     return this.hydrateSingle(await attachUserData(toRecord(doc)));
   }
 
+  async updateSkillsAndBio(
+    id: string, 
+    categories: string[], 
+    skills: FixerSkillInput[], 
+    bio?: string
+  ) {
+    const updateData: UpdateFixerDTO = { categories, skills };
+    
+    // ✅ Solo incluir bio si fue proporcionado explícitamente
+    if (bio !== undefined) {
+      updateData.bio = bio;
+    }
+    
+    return this.update(id, updateData);
+  }
+
   async getById(id: string) {
     const doc = await FixerModel.findOne(buildIdQuery(id));
     return this.hydrateSingle(await attachUserData(toRecord(doc)));


### PR DESCRIPTION
- Actualizado updateCategories para aceptar y validar bio
- Validación: 20-500 caracteres
- Usa service.update() directamente (consistente con createFixer)
- Bio se guarda y recupera correctamente de la BD

Resolves: Bug 1.1.1
Assigned: Daniel Iriarte Zeballos